### PR TITLE
Configure API URL and CORS defaults for Vercel + Render deployment

### DIFF
--- a/new website/README.md
+++ b/new website/README.md
@@ -56,6 +56,14 @@ cp .env.example .env
 npm start
 ```
 
+For production frontend deployments (for example Vercel), set:
+
+```env
+REACT_APP_API_URL=https://job-aggregator-website.onrender.com/api
+```
+
+If you migrate to Vite later, use `VITE_API_URL` instead.
+
 ## Team images
 
 Put your real JPEGs in `frontend/public/team/` using these names:
@@ -110,3 +118,14 @@ In Google Cloud Console -> Credentials -> OAuth Client:
   - `backend/.env` -> `GOOGLE_CLIENT_ID`
 
 Username/password registration/login will work even when Google is misconfigured.
+
+### 5) Frontend deployed but API calls fail
+If your React frontend is on Vercel and backend is on Render:
+
+1. In Vercel project settings, set:
+   - `REACT_APP_API_URL=https://job-aggregator-website.onrender.com/api`
+2. In Render backend environment, set:
+   - `ALLOWED_HOSTS=job-aggregator-website.onrender.com,...`
+   - `CORS_ALLOWED_ORIGINS=https://your-frontend.vercel.app,...`
+
+If you use Vercel preview deployments, allow `https://*.vercel.app` with Django `CORS_ALLOWED_ORIGIN_REGEXES`.

--- a/new website/backend/.env.example
+++ b/new website/backend/.env.example
@@ -1,7 +1,7 @@
 DEBUG=1
 DJANGO_SECRET_KEY=change-this
-ALLOWED_HOSTS=127.0.0.1,localhost
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+ALLOWED_HOSTS=127.0.0.1,localhost,job-aggregator-website.onrender.com
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://your-frontend.vercel.app
 
 DB_ENGINE=sqlite
 # DB_ENGINE=postgres

--- a/new website/backend/job_aggregator/settings.py
+++ b/new website/backend/job_aggregator/settings.py
@@ -8,13 +8,18 @@ load_dotenv(BASE_DIR / '.env')
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'dev-secret-key-change-me')
 DEBUG = os.getenv('DEBUG', '1') == '1'
-ALLOWED_HOSTS = [
-    'romer.pythonanywhere.com',
-    'cpe3cjobaggregator.com',
-    'www.cpe3cjobaggregator.com',
-    '127.0.0.1',
-    'localhost'
-]
+
+
+def _split_csv(value):
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+ALLOWED_HOSTS = _split_csv(
+    os.getenv(
+        'ALLOWED_HOSTS',
+        'romer.pythonanywhere.com,cpe3cjobaggregator.com,www.cpe3cjobaggregator.com,job-aggregator-website.onrender.com,127.0.0.1,localhost'
+    )
+)
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -95,7 +100,15 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', 'http://localhost:3000,http://127.0.0.1:3000').split(',')
+CORS_ALLOWED_ORIGINS = _split_csv(
+    os.getenv(
+        'CORS_ALLOWED_ORIGINS',
+        'http://localhost:3000,http://127.0.0.1:3000'
+    )
+)
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r'^https://.*\.vercel\.app$',
+]
 
 REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (

--- a/new website/frontend/.env.example
+++ b/new website/frontend/.env.example
@@ -1,3 +1,7 @@
+REACT_APP_API_URL=http://127.0.0.1:8000/api
+# Backward-compatible alias used by older builds.
 REACT_APP_API_BASE_URL=http://127.0.0.1:8000/api
+# If you migrate this frontend to Vite, use:
+# VITE_API_URL=http://127.0.0.1:8000/api
 # Use Google OAuth "Client ID" (ends with .apps.googleusercontent.com), never the client secret.
 REACT_APP_GOOGLE_CLIENT_ID=179901585453-fvssj2iusk5pk11obbottoaaeojdj78s.apps.googleusercontent.com

--- a/new website/frontend/src/api/client.js
+++ b/new website/frontend/src/api/client.js
@@ -1,7 +1,16 @@
 import axios from 'axios';
 
+const DEFAULT_API_URL = 'https://job-aggregator-website.onrender.com/api';
+
+const rawBaseUrl =
+  process.env.REACT_APP_API_URL ||
+  process.env.REACT_APP_API_BASE_URL ||
+  DEFAULT_API_URL;
+
+const normalizedBaseUrl = rawBaseUrl.replace(/\/+$/, '');
+
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_BASE_URL || 'http://127.0.0.1:8000/api',
+  baseURL: normalizedBaseUrl,
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
### Motivation
- Fix broken frontend API calls after deploying the React frontend on Vercel and Django backend on Render by making the API base URL explicit and configurable.
- Centralize API URL handling in the Axios client so all pages use the same deploy-time-configurable endpoint.
- Ensure backend CORS and `ALLOWED_HOSTS` are flexible for Render hostnames and Vercel preview domains.

### Description
- Updated `new website/frontend/src/api/client.js` to prefer `REACT_APP_API_URL` (fallback to legacy `REACT_APP_API_BASE_URL`) and default to `https://job-aggregator-website.onrender.com/api`, and to normalize trailing slashes before creating the Axios instance. 
- Added `REACT_APP_API_URL` and a `VITE_API_URL` migration note to `new website/frontend/.env.example` while keeping `REACT_APP_API_BASE_URL` as a backward-compatible alias. 
- Modified `new website/backend/job_aggregator/settings.py` to parse CSV env vars with a `_split_csv` helper, include the Render host by default in `ALLOWED_HOSTS`, and add `CORS_ALLOWED_ORIGIN_REGEXES` to allow `*.vercel.app` preview domains. 
- Updated `new website/backend/.env.example` and `new website/README.md` with environment variable examples and deployment troubleshooting steps for Vercel + Render setups. 

### Testing
- Located frontend API usage with `rg` to verify all calls go through the centralized Axios client; the search completed successfully. 
- Attempted `npm run build` in `new website/frontend`, which failed in this environment because `react-scripts` is not installed, so a local production build was not produced here. 
- Verified file changes and created a commit (`git commit`) successfully in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71cf21310832e9f12d473845e8810)