### PR TITLE
Support Vercel/Render deployment: env, CORS, API URL normalization, and docs updates

### DIFF
--- a/new website/README.md
+++ b/new website/README.md
@@ -56,6 +56,14 @@ cp .env.example .env
 npm start
 ```
 
+For production frontend deployments (for example Vercel), set:
+
+```env
+REACT_APP_API_URL=https://job-aggregator-website.onrender.com/api
+```
+
+If you migrate to Vite later, use `VITE_API_URL` instead.
+
 ## Team images
 
 Put your real JPEGs in `frontend/public/team/` using these names:
@@ -76,6 +84,7 @@ In Google Cloud Console, add these **Authorized JavaScript origins**:
 
 Also ensure `REACT_APP_GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_ID` match.
 Use the Google OAuth **Client ID** only (`...apps.googleusercontent.com`), not `GOCSPX-...` client secrets.
+If deployed on Vercel, set `REACT_APP_GOOGLE_CLIENT_ID` in Vercel Environment Variables and redeploy.
 
 ### 2) "Could not refresh jobs" from Adzuna
 Set these in `backend/.env`:
@@ -110,3 +119,14 @@ In Google Cloud Console -> Credentials -> OAuth Client:
   - `backend/.env` -> `GOOGLE_CLIENT_ID`
 
 Username/password registration/login will work even when Google is misconfigured.
+
+### 5) Frontend deployed but API calls fail
+If your React frontend is on Vercel and backend is on Render:
+
+1. In Vercel project settings, set:
+   - `REACT_APP_API_URL=https://job-aggregator-website.onrender.com/api`
+2. In Render backend environment, set:
+   - `ALLOWED_HOSTS=job-aggregator-website.onrender.com,...`
+   - `CORS_ALLOWED_ORIGINS=https://your-frontend.vercel.app,...`
+
+If you use Vercel preview deployments, allow `https://*.vercel.app` with Django `CORS_ALLOWED_ORIGIN_REGEXES`.

--- a/new website/backend/.env.example
+++ b/new website/backend/.env.example
@@ -1,7 +1,7 @@
 DEBUG=1
 DJANGO_SECRET_KEY=change-this
-ALLOWED_HOSTS=127.0.0.1,localhost
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+ALLOWED_HOSTS=127.0.0.1,localhost,job-aggregator-website.onrender.com
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://your-frontend.vercel.app
 
 DB_ENGINE=sqlite
 # DB_ENGINE=postgres

--- a/new website/backend/job_aggregator/settings.py
+++ b/new website/backend/job_aggregator/settings.py
@@ -8,13 +8,18 @@ load_dotenv(BASE_DIR / '.env')
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'dev-secret-key-change-me')
 DEBUG = os.getenv('DEBUG', '1') == '1'
-ALLOWED_HOSTS = [
-    'romer.pythonanywhere.com',
-    'cpe3cjobaggregator.com',
-    'www.cpe3cjobaggregator.com',
-    '127.0.0.1',
-    'localhost'
-]
+
+
+def _split_csv(value):
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+ALLOWED_HOSTS = _split_csv(
+    os.getenv(
+        'ALLOWED_HOSTS',
+        'romer.pythonanywhere.com,cpe3cjobaggregator.com,www.cpe3cjobaggregator.com,job-aggregator-website.onrender.com,127.0.0.1,localhost'
+    )
+)
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -95,7 +100,15 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', 'http://localhost:3000,http://127.0.0.1:3000').split(',')
+CORS_ALLOWED_ORIGINS = _split_csv(
+    os.getenv(
+        'CORS_ALLOWED_ORIGINS',
+        'http://localhost:3000,http://127.0.0.1:3000'
+    )
+)
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r'^https://.*\.vercel\.app$',
+]
 
 REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (

--- a/new website/frontend/.env.example
+++ b/new website/frontend/.env.example
@@ -1,3 +1,7 @@
+REACT_APP_API_URL=http://127.0.0.1:8000/api
+# Backward-compatible alias used by older builds.
 REACT_APP_API_BASE_URL=http://127.0.0.1:8000/api
+# If you migrate this frontend to Vite, use:
+# VITE_API_URL=http://127.0.0.1:8000/api
 # Use Google OAuth "Client ID" (ends with .apps.googleusercontent.com), never the client secret.
 REACT_APP_GOOGLE_CLIENT_ID=179901585453-fvssj2iusk5pk11obbottoaaeojdj78s.apps.googleusercontent.com

--- a/new website/frontend/src/api/client.js
+++ b/new website/frontend/src/api/client.js
@@ -1,7 +1,16 @@
 import axios from 'axios';
 
+const DEFAULT_API_URL = 'https://job-aggregator-website.onrender.com/api';
+
+const rawBaseUrl =
+  process.env.REACT_APP_API_URL ||
+  process.env.REACT_APP_API_BASE_URL ||
+  DEFAULT_API_URL;
+
+const normalizedBaseUrl = rawBaseUrl.replace(/\/+$/, '');
+
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_BASE_URL || 'http://127.0.0.1:8000/api',
+  baseURL: normalizedBaseUrl,
 });
 
 api.interceptors.request.use((config) => {

--- a/new website/frontend/src/components/GoogleSignInButton.jsx
+++ b/new website/frontend/src/components/GoogleSignInButton.jsx
@@ -9,7 +9,9 @@ const GoogleSignInButton = ({ onCredential, onError }) => {
     setReady(false);
 
     if (!clientId) {
-      onError?.('Google login is disabled: missing REACT_APP_GOOGLE_CLIENT_ID in frontend/.env');
+      onError?.(
+        'Google login is disabled: missing REACT_APP_GOOGLE_CLIENT_ID. Set it in frontend/.env (local) or in your Vercel Environment Variables.'
+      );
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Allow frontend deployments (e.g. Vercel) to talk to a hosted backend by providing sensible production defaults and clearer deployment troubleshooting.
- Make backend host and CORS configuration flexible via environment variables and allow common Vercel preview origins.
- Improve frontend API base URL resolution and Google Sign-In error messaging for users deploying off localhost.

### Description
- Parse comma-separated `ALLOWED_HOSTS` and `CORS_ALLOWED_ORIGINS` from the environment using a `_split_csv` helper and set the defaults to include `job-aggregator-website.onrender.com` and a Vercel placeholder origin in `job_aggregator/settings.py`.
- Add `CORS_ALLOWED_ORIGIN_REGEXES` to allow `https://*.vercel.app` preview deployments in `job_aggregator/settings.py`.
- Update `backend/.env.example` to include the new host and CORS defaults.
- Normalize and prioritize frontend API base URL resolution in `frontend/src/api/client.js` by reading `REACT_APP_API_URL`, falling back to `REACT_APP_API_BASE_URL`, and trimming trailing slashes with a `DEFAULT_API_URL` fallback.
- Add `REACT_APP_API_URL` and Vite alias notes to `frontend/.env.example`.
- Improve `GoogleSignInButton` error text to mention setting `REACT_APP_GOOGLE_CLIENT_ID` in local `.env` or Vercel Environment Variables and keep the client-secret guard.
- Extend `README.md` with production deployment notes, Vercel environment variable guidance, and a new troubleshooting item for frontend/API CORS and host configuration.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71cf21310832e9f12d473845e8810)